### PR TITLE
[WIP] Rewrote the URL dispatcher API.

### DIFF
--- a/django/conf/urls/__init__.py
+++ b/django/conf/urls/__init__.py
@@ -1,12 +1,12 @@
 import warnings
 from importlib import import_module
+from types import ModuleType
 
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import (
-    LocaleRegexURLResolver, RegexURLPattern, RegexURLResolver,
-)
+from django.urls.utils import describe_constraints
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.functional import Promise
 
 __all__ = ['handler400', 'handler403', 'handler404', 'handler500', 'include', 'url']
 
@@ -17,6 +17,8 @@ handler500 = 'django.views.defaults.server_error'
 
 
 def include(arg, namespace=None, app_name=None):
+    from django.urls import LocalePrefix
+
     if app_name and not namespace:
         raise ValueError('Must specify a namespace if specifying app_name.')
     if app_name:
@@ -48,8 +50,10 @@ def include(arg, namespace=None, app_name=None):
 
     if isinstance(urlconf_module, six.string_types):
         urlconf_module = import_module(urlconf_module)
-    patterns = getattr(urlconf_module, 'urlpatterns', urlconf_module)
+    urlpatterns = getattr(urlconf_module, 'urlpatterns', urlconf_module)
     app_name = getattr(urlconf_module, 'app_name', app_name)
+    namespace = namespace or app_name
+
     if namespace and not app_name:
         warnings.warn(
             'Specifying a namespace in django.conf.urls.include() without '
@@ -59,27 +63,121 @@ def include(arg, namespace=None, app_name=None):
             RemovedInDjango20Warning, stacklevel=2
         )
 
-    namespace = namespace or app_name
-
     # Make sure we can iterate through the patterns (without this, some
     # testcases will break).
-    if isinstance(patterns, (list, tuple)):
-        for url_pattern in patterns:
+    if isinstance(urlpatterns, (list, tuple)):
+        for urlpattern in urlpatterns:
             # Test if the LocaleRegexURLResolver is used within the include;
             # this should throw an error since this is not allowed!
-            if isinstance(url_pattern, LocaleRegexURLResolver):
-                raise ImproperlyConfigured(
-                    'Using i18n_patterns in an included URLconf is not allowed.')
+            if any(isinstance(constraint, LocalePrefix) for constraint in urlpattern.constraints):
+                raise ImproperlyConfigured('Using i18n_patterns in an included URLconf is not allowed.')
 
-    return (urlconf_module, app_name, namespace)
+    return urlconf_module, app_name, namespace
 
 
-def url(regex, view, kwargs=None, name=None):
+def url(regex, view, kwargs=None, name=None, decorators=None, resolver_cls=None):
+    from django.urls import RegexPattern, LocalizedRegexPattern
+
+    if isinstance(regex, six.string_types):
+        regex = RegexPattern(regex)
+    elif isinstance(regex, Promise):
+        regex = LocalizedRegexPattern(regex)
+
+    if not isinstance(regex, (list, tuple)):
+        constraints = [regex]
+    else:
+        constraints = regex
+
     if isinstance(view, (list, tuple)):
-        # For include(...) processing.
-        urlconf_module, app_name, namespace = view
-        return RegexURLResolver(regex, urlconf_module, kwargs, app_name=app_name, namespace=namespace)
+        urlconf, app_name, namespace = view
+        return URLPattern(constraints, URLConf(urlconf, app_name, namespace, kwargs, decorators, resolver_cls))
     elif callable(view):
-        return RegexURLPattern(regex, view, kwargs, name)
+        return URLPattern(constraints, Endpoint(view, name, kwargs, decorators, resolver_cls))
     else:
         raise TypeError('view must be a callable or a list/tuple in the case of include().')
+
+
+class Endpoint(object):
+    def __init__(self, view, url_name=None, kwargs=None, decorators=None, resolver_cls=None):
+        self.view = view
+        self.url_name = url_name
+        self.kwargs = kwargs or {}
+        self.decorators = decorators or []
+        self.resolver_cls = resolver_cls
+
+    def __repr__(self):
+        return "<Endpoint '%s'%s>" % (self.lookup_str, " [name='%s']" % self.url_name if self.url_name else '')
+
+    @property
+    def lookup_str(self):
+        from django.urls.utils import get_lookup_string
+        return get_lookup_string(self.view)
+
+    def get_resolver_cls(self):
+        from django.urls import ResolverEndpoint
+        return self.resolver_cls or ResolverEndpoint
+
+
+class URLPattern(object):
+    def __init__(self, constraints, target):
+        self.constraints = constraints
+        self.target = target
+
+    def __repr__(self):
+        return "<URLPattern %s target=%r>" % (describe_constraints(self.constraints), self.target)
+
+    def is_endpoint(self):
+        return isinstance(self.target, Endpoint)
+
+    def as_resolver(self, **kwargs):
+        cls = self.target.get_resolver_cls()
+        return cls(self, **kwargs)
+
+
+class URLConf(object):
+    def __init__(self, urlconf, app_name=None, namespace=None, kwargs=None, decorators=None, resolver_cls=None):
+        self.urlconf_name = urlconf
+        self.app_name = app_name
+        self.namespace = namespace
+        self.kwargs = kwargs or {}
+        self._decorators = decorators or []
+        self.resolver_cls = resolver_cls
+
+    def __repr__(self):
+        urlconf_name = self.urlconf_name
+        if isinstance(urlconf_name, (list, tuple)) and len(urlconf_name):
+            urlconf_repr = '<%s list>' % self.urlpatterns[0].__class__.__name__
+        elif isinstance(urlconf_name, ModuleType):
+            urlconf_repr = repr(urlconf_name.__name__)
+        else:
+            urlconf_repr = repr(urlconf_name)
+        return '<URLConf %s (%s)>' % (urlconf_repr, self.app_name)
+
+    @property
+    def urlconf_module(self):
+        if isinstance(self.urlconf_name, six.string_types):
+            return import_module(self.urlconf_name)
+        else:
+            return self.urlconf_name
+
+    @property
+    def urlpatterns(self):
+        urlpatterns = getattr(self.urlconf_module, 'urlpatterns', self.urlconf_module)
+        try:
+            iter(urlpatterns)
+        except TypeError:
+            msg = (
+                "The included URLconf '{name}' does not appear to have any "
+                "patterns in it. If you see valid patterns in the file then "
+                "the issue is probably caused by a circular import."
+            )
+            raise ImproperlyConfigured(msg.format(name=self.urlconf_name))
+        return urlpatterns
+
+    @property
+    def decorators(self):
+        return self._decorators + getattr(self.urlconf_module, 'decorators', [])
+
+    def get_resolver_cls(self):
+        from django.urls import Resolver
+        return self.resolver_cls or getattr(self.urlconf_module, 'resolver_cls', Resolver)

--- a/django/contrib/admin/templatetags/admin_urls.py
+++ b/django/contrib/admin/templatetags/admin_urls.py
@@ -22,6 +22,11 @@ def add_preserved_filters(context, url, popup=False, to_field=None):
     opts = context.get('opts')
     preserved_filters = context.get('preserved_filters')
 
+    try:
+        request = context.request
+    except AttributeError:
+        request = None
+
     parsed_url = list(urlparse(url))
     parsed_qs = dict(parse_qsl(parsed_url[4]))
     merged_qs = dict()
@@ -31,7 +36,7 @@ def add_preserved_filters(context, url, popup=False, to_field=None):
 
         match_url = '/%s' % url.partition(get_script_prefix())[2]
         try:
-            match = resolve(match_url)
+            match = resolve(match_url, request=request)
         except Resolver404:
             pass
         else:

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -8,11 +8,13 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.admindocs import utils
-from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.http import Http404
 from django.template.engine import Engine
-from django.urls import get_mod_func, get_resolver, get_urlconf, reverse
+from django.urls import (
+    describe_constraints, get_dispatcher, get_mod_func, get_urlconf, reverse,
+)
 from django.utils.decorators import method_decorator
 from django.utils.inspect import (
     func_accepts_kwargs, func_accepts_var_args, func_has_no_args,
@@ -147,8 +149,11 @@ class ViewDetailView(BaseAdminDocsView):
 
     def get_context_data(self, **kwargs):
         view = self.kwargs['view']
-        urlconf = get_urlconf()
-        if get_resolver(urlconf)._is_callback(view):
+        dispatcher = get_dispatcher(get_urlconf())
+        # Private API, may not exist if using a custom dispatcher
+        if not hasattr(dispatcher, 'is_callback'):
+            raise Http404
+        if dispatcher.is_callback(view):
             mod, func = get_mod_func(view)
             view_func = getattr(import_module(mod), func)
         else:
@@ -360,32 +365,32 @@ def get_readable_field_data_type(field):
     return field.description % field.__dict__
 
 
-def extract_views_from_urlpatterns(urlpatterns, base='', namespace=None):
+def extract_views_from_urlpatterns(urlpatterns, base=None, namespace=None):
     """
     Return a list of views from a list of urlpatterns.
 
     Each object in the returned list is a two-tuple: (view_func, regex)
     """
     views = []
-    for p in urlpatterns:
-        if hasattr(p, 'url_patterns'):
+    for urlpattern in urlpatterns:
+        try:
+            name = urlpattern.target.namespace if not urlpattern.is_endpoint() else None
+        except AttributeError:
+            raise TypeError(_("%s does not appear to be a URLPattern object") % urlpattern)
+        if urlpattern.is_endpoint():
+            views.append((
+                urlpattern.target.view, describe_constraints((base or []) + urlpattern.constraints),
+                namespace, urlpattern.target.url_name,
+            ))
+        else:
             try:
-                patterns = p.url_patterns
+                sub_urlpatterns = urlpattern.target.urlpatterns
             except ImportError:
                 continue
             views.extend(extract_views_from_urlpatterns(
-                patterns,
-                base + p.regex.pattern,
-                (namespace or []) + (p.namespace and [p.namespace] or [])
+                sub_urlpatterns, (base or []) + urlpattern.constraints,
+                (namespace or []) + (name and [name] or []),
             ))
-        elif hasattr(p, 'callback'):
-            try:
-                views.append((p.callback, base + p.regex.pattern,
-                              namespace, p.name))
-            except ViewDoesNotExist:
-                continue
-        else:
-            raise TypeError(_("%s does not appear to be a urlpattern object") % p)
     return views
 
 named_group_matcher = re.compile(r'\(\?P(<\w+>).+?\)')

--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -1,89 +1,96 @@
 from __future__ import unicode_literals
 
-from django.conf import settings
+from importlib import import_module
 
 from . import Tags, Warning, register
 
 
 @register(Tags.urls)
 def check_url_config(app_configs, **kwargs):
+    from django.conf import settings
     if getattr(settings, 'ROOT_URLCONF', None):
-        from django.urls import get_resolver
-        resolver = get_resolver()
-        return check_resolver(resolver)
+        urlconf = import_module(settings.ROOT_URLCONF)
+        return check_urlconf(urlconf)
     return []
 
 
-def check_resolver(resolver):
+def check_urlconf(urlconf):
     """
-    Recursively check the resolver.
+    Recursively check the URLconf.
     """
-    from django.urls import RegexURLPattern, RegexURLResolver
     warnings = []
-    for pattern in resolver.url_patterns:
-        if isinstance(pattern, RegexURLResolver):
-            warnings.extend(check_include_trailing_dollar(pattern))
-            # Check resolver recursively
-            warnings.extend(check_resolver(pattern))
-        elif isinstance(pattern, RegexURLPattern):
-            warnings.extend(check_pattern_name(pattern))
+    for urlpattern in urlconf.urlpatterns:
+        if urlpattern.is_endpoint():
+            warnings.extend(check_pattern_name(urlpattern))
+        else:
+            warnings.extend(check_include_trailing_dollar(urlpattern))
+            # check URLconf recursively
+            warnings.extend(check_urlconf(urlpattern.target))
 
-        warnings.extend(check_pattern_startswith_slash(pattern))
+        warnings.extend(check_pattern_startswith_slash(urlpattern))
 
     return warnings
 
 
-def describe_pattern(pattern):
+def describe_pattern(urlpattern):
     """
     Format the URL pattern for display in warning messages.
     """
-    description = "'{}'".format(pattern.regex.pattern)
-    if getattr(pattern, 'name', False):
-        description += " [name='{}']".format(pattern.name)
+    from django.urls import describe_constraints
+
+    description = "'%s'" % describe_constraints(urlpattern.constraints)
+    if getattr(urlpattern.target, 'url_name', False):
+        description += " [name='{}']".format(urlpattern.target.url_name)
     return description
 
 
-def check_include_trailing_dollar(pattern):
+def check_include_trailing_dollar(urlpattern):
     """
     Check that include is not used with a regex ending with a dollar.
     """
-    regex_pattern = pattern.regex.pattern
-    if regex_pattern.endswith('$') and not regex_pattern.endswith('\$'):
-        warning = Warning(
-            "Your URL pattern {} uses include with a regex ending with a '$'. "
-            "Remove the dollar from the regex to avoid problems including "
-            "URLs.".format(describe_pattern(pattern)),
-            id="urls.W001",
-        )
-        return [warning]
-    else:
-        return []
+    from django.urls import RegexPattern
+    warnings = []
+    for constraint in urlpattern.constraints:
+        if isinstance(constraint, RegexPattern):
+            regex_pattern = constraint.regex.pattern
+            if regex_pattern.endswith('$') and not regex_pattern.endswith('\$'):
+                warning = Warning(
+                    "Your URL pattern {} uses include with a regex ending with a '$'. "
+                    "Remove the dollar from the regex to avoid problems including "
+                    "URLs.".format(describe_pattern(urlpattern)),
+                    id="urls.W001",
+                )
+                warnings.append(warning)
+    return warnings
 
 
-def check_pattern_startswith_slash(pattern):
+def check_pattern_startswith_slash(urlpattern):
     """
     Check that the pattern does not begin with a forward slash.
     """
-    regex_pattern = pattern.regex.pattern
-    if regex_pattern.startswith('/') or regex_pattern.startswith('^/'):
-        warning = Warning(
-            "Your URL pattern {} has a regex beginning with a '/'. "
-            "Remove this slash as it is unnecessary.".format(describe_pattern(pattern)),
-            id="urls.W002",
-        )
-        return [warning]
-    else:
-        return []
+    from django.urls import RegexPattern
+    warnings = []
+    for constraint in urlpattern.constraints:
+        if isinstance(constraint, RegexPattern):
+            regex_pattern = constraint.regex.pattern
+            if regex_pattern.startswith('/') or regex_pattern.startswith('^/'):
+                warning = Warning(
+                    "Your URL pattern {} has a regex beginning with a '/'. "
+                    "Remove this slash as it is unnecessary.".format(describe_pattern(urlpattern)),
+                    id="urls.W002",
+                )
+                warnings.append(warning)
+    return warnings
 
 
-def check_pattern_name(pattern):
+def check_pattern_name(urlpattern):
     """
     Check that the pattern name does not contain a colon.
     """
-    if pattern.name is not None and ":" in pattern.name:
+    if urlpattern.target.url_name is not None and ":" in urlpattern.target.url_name:
         warning = Warning(
             "Your URL pattern {} has a name including a ':'. Remove the colon, to "
-            "avoid ambiguous namespace references.".format(describe_pattern(pattern)),
+            "avoid ambiguous namespace references.".format(describe_pattern(urlpattern)),
             id="urls.W003",
         )
         return [warning]

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -13,7 +13,7 @@ from django.core.exceptions import (
 )
 from django.db import connections, transaction
 from django.http.multipartparser import MultiPartParserError
-from django.urls import get_resolver, set_urlconf
+from django.urls import get_dispatcher, get_urlconf, set_urlconf
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text
@@ -83,9 +83,9 @@ class BaseHandler(object):
                 view = transaction.atomic(using=db.alias)(view)
         return view
 
-    def get_exception_response(self, request, resolver, status_code, exception):
+    def get_exception_response(self, request, dispatcher, status_code, exception):
         try:
-            callback, param_dict = resolver.resolve_error_handler(status_code)
+            callback, param_dict = dispatcher.resolve_error_handler(status_code)
             # Unfortunately, inspect.getargspec result is not trustable enough
             # depending on the callback wrapping in decorators (frequent for handlers).
             # Falling back on try/except:
@@ -100,20 +100,19 @@ class BaseHandler(object):
                 response = callback(request, **param_dict)
         except Exception:
             signals.got_request_exception.send(sender=self.__class__, request=request)
-            response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
+            response = self.handle_uncaught_exception(request, dispatcher, sys.exc_info())
 
         return response
 
     def get_response(self, request):
         "Returns an HttpResponse object for the given HttpRequest"
 
-        # Setup default url resolver for this thread, this code is outside
+        # Reset default url dispatcher for this thread, this code is outside
         # the try/except so we don't get a spurious "unbound local
         # variable" exception in the event an exception is raised before
-        # resolver is set
-        urlconf = settings.ROOT_URLCONF
-        set_urlconf(urlconf)
-        resolver = get_resolver(urlconf)
+        # dispatcher is set
+        set_urlconf(None)
+        dispatcher = get_dispatcher(get_urlconf())
         # Use a flag to check if the response was rendered to prevent
         # multiple renderings or to force rendering if necessary.
         response_is_rendered = False
@@ -127,12 +126,11 @@ class BaseHandler(object):
 
             if response is None:
                 if hasattr(request, 'urlconf'):
-                    # Reset url resolver with a custom URLconf.
-                    urlconf = request.urlconf
-                    set_urlconf(urlconf)
-                    resolver = get_resolver(urlconf)
+                    # Reset url dispatcher with a custom URLconf.
+                    set_urlconf(request.urlconf)
+                    dispatcher = get_dispatcher(get_urlconf())
 
-                resolver_match = resolver.resolve(request.path_info)
+                resolver_match = dispatcher.resolve(request.path_info, request)
                 callback, callback_args, callback_kwargs = resolver_match
                 request.resolver_match = resolver_match
 
@@ -185,7 +183,7 @@ class BaseHandler(object):
             if settings.DEBUG:
                 response = debug.technical_404_response(request, exc)
             else:
-                response = self.get_exception_response(request, resolver, 404, exc)
+                response = self.get_exception_response(request, dispatcher, 404, exc)
 
         except PermissionDenied as exc:
             logger.warning(
@@ -194,7 +192,7 @@ class BaseHandler(object):
                     'status_code': 403,
                     'request': request
                 })
-            response = self.get_exception_response(request, resolver, 403, exc)
+            response = self.get_exception_response(request, dispatcher, 403, exc)
 
         except MultiPartParserError as exc:
             logger.warning(
@@ -203,7 +201,7 @@ class BaseHandler(object):
                     'status_code': 400,
                     'request': request
                 })
-            response = self.get_exception_response(request, resolver, 400, exc)
+            response = self.get_exception_response(request, dispatcher, 400, exc)
 
         except SuspiciousOperation as exc:
             # The request logger receives events for any problematic request
@@ -219,7 +217,7 @@ class BaseHandler(object):
             if settings.DEBUG:
                 return debug.technical_500_response(request, *sys.exc_info(), status_code=400)
 
-            response = self.get_exception_response(request, resolver, 400, exc)
+            response = self.get_exception_response(request, dispatcher, 400, exc)
 
         except SystemExit:
             # Allow sys.exit() to actually exit. See tickets #1023 and #4701
@@ -228,7 +226,7 @@ class BaseHandler(object):
         except Exception:  # Handle everything else.
             # Get the exception info now, in case another exception is thrown later.
             signals.got_request_exception.send(sender=self.__class__, request=request)
-            response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
+            response = self.handle_uncaught_exception(request, dispatcher, sys.exc_info())
 
         try:
             # Apply response middleware, regardless of the response
@@ -243,7 +241,7 @@ class BaseHandler(object):
             response = self.apply_response_fixes(request, response)
         except Exception:  # Any exception should be gathered and handled
             signals.got_request_exception.send(sender=self.__class__, request=request)
-            response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
+            response = self.handle_uncaught_exception(request, dispatcher, sys.exc_info())
 
         response._closable_objects.append(request)
 
@@ -265,7 +263,7 @@ class BaseHandler(object):
                 return response
         raise
 
-    def handle_uncaught_exception(self, request, resolver, exc_info):
+    def handle_uncaught_exception(self, request, dispatcher, exc_info):
         """
         Processing for any otherwise uncaught exceptions (those that will
         generate HTTP 500 responses). Can be overridden by subclasses who want
@@ -289,11 +287,8 @@ class BaseHandler(object):
         if settings.DEBUG:
             return debug.technical_500_response(request, *exc_info)
 
-        # If Http500 handler is not installed, re-raise last exception
-        if resolver.urlconf_module is None:
-            six.reraise(*exc_info)
         # Return an HttpResponse that displays a friendly error message.
-        callback, param_dict = resolver.resolve_error_handler(500)
+        callback, param_dict = dispatcher.resolve_error_handler(500)
         return callback(request, **param_dict)
 
     def apply_response_fixes(self, request, response):

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -76,8 +76,8 @@ class CommonMiddleware(object):
         if settings.APPEND_SLASH and not request.get_full_path().endswith('/'):
             urlconf = getattr(request, 'urlconf', None)
             return (
-                not is_valid_path(request.path_info, urlconf)
-                and is_valid_path('%s/' % request.path_info, urlconf)
+                not is_valid_path(request.path_info, urlconf, request)
+                and is_valid_path('%s/' % request.path_info, urlconf, request)
             )
         return False
 

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -36,11 +36,11 @@ class LocaleMiddleware(object):
 
         if response.status_code == 404 and not language_from_path and i18n_patterns_used:
             language_path = '/%s%s' % (language, request.path_info)
-            path_valid = is_valid_path(language_path, urlconf)
+            path_valid = is_valid_path(language_path, urlconf, request)
             path_needs_slash = (
                 not path_valid and (
                     settings.APPEND_SLASH and not language_path.endswith('/')
-                    and is_valid_path('%s/' % language_path, urlconf)
+                    and is_valid_path('%s/' % language_path, urlconf, request)
                 )
             )
 

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -483,7 +483,9 @@ class Client(RequestFactory):
             response.json = curry(self._parse_json, response)
 
             # Attach the ResolverMatch instance to the response
-            response.resolver_match = SimpleLazyObject(lambda: resolve(request['PATH_INFO']))
+            response.resolver_match = SimpleLazyObject(
+                lambda: resolve(request['PATH_INFO'], request=request)
+            )
 
             # Flatten a single context. Not really necessary anymore thanks to
             # the __getattr__ flattening in ContextList, but has some edge-case

--- a/django/urls/__init__.py
+++ b/django/urls/__init__.py
@@ -1,20 +1,25 @@
-from .base import (
+from django.urls.base import (
     clear_script_prefix, clear_url_caches, get_script_prefix, get_urlconf,
     is_valid_path, resolve, reverse, reverse_lazy, set_script_prefix,
     set_urlconf, translate_url,
 )
-from .exceptions import NoReverseMatch, Resolver404
-from .resolvers import (
-    LocaleRegexProvider, LocaleRegexURLResolver, RegexURLPattern,
-    RegexURLResolver, ResolverMatch, get_ns_resolver, get_resolver,
+from django.urls.constraints import (
+    Constraint, LocalePrefix, LocalizedRegexPattern, RegexPattern,
+    ScriptPrefix,
 )
-from .utils import get_callable, get_mod_func
+from django.urls.dispatcher import Dispatcher, get_dispatcher
+from django.urls.exceptions import NoReverseMatch, Resolver404
+from django.urls.resolvers import (
+    BaseResolver, Resolver, ResolverEndpoint, ResolverMatch,
+)
+from django.urls.utils import (
+    URL, describe_constraints, get_callable, get_mod_func,
+)
 
 __all__ = [
-    'LocaleRegexProvider', 'LocaleRegexURLResolver', 'NoReverseMatch',
-    'RegexURLPattern', 'RegexURLResolver', 'Resolver404', 'ResolverMatch',
-    'clear_script_prefix', 'clear_url_caches', 'get_callable', 'get_mod_func',
-    'get_ns_resolver', 'get_resolver', 'get_script_prefix', 'get_urlconf',
-    'is_valid_path', 'resolve', 'reverse', 'reverse_lazy', 'set_script_prefix',
-    'set_urlconf', 'translate_url',
+    'BaseResolver', 'Constraint', 'Dispatcher', 'LocalePrefix', 'LocalizedRegexPattern', 'NoReverseMatch',
+    'RegexPattern', 'Resolver', 'Resolver404', 'ResolverEndpoint', 'ResolverMatch', 'ScriptPrefix', 'URL',
+    'clear_script_prefix', 'clear_url_caches', 'describe_constraints', 'get_callable', 'get_dispatcher',
+    'get_mod_func', 'get_script_prefix', 'get_urlconf', 'is_valid_path', 'resolve', 'reverse', 'reverse_lazy',
+    'set_script_prefix', 'set_urlconf', 'translate_url',
 ]

--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -3,13 +3,10 @@ from __future__ import unicode_literals
 from threading import local
 
 from django.utils import six
-from django.utils.encoding import force_text, iri_to_uri
+from django.utils.encoding import force_text
 from django.utils.functional import lazy
-from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
-from django.utils.translation import override
 
-from .exceptions import NoReverseMatch, Resolver404
-from .resolvers import get_ns_resolver, get_resolver
+from .dispatcher import get_dispatcher
 from .utils import get_callable
 
 # SCRIPT_NAME prefixes for each thread are stored here. If there's no entry for
@@ -21,82 +18,31 @@ _prefixes = local()
 _urlconfs = local()
 
 
-def resolve(path, urlconf=None):
+def resolve(path, urlconf=None, request=None):
+    path = force_text(path)
     if urlconf is None:
         urlconf = get_urlconf()
-    return get_resolver(urlconf).resolve(path)
+    return get_dispatcher(urlconf).resolve(path, request)
 
 
 def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
     if urlconf is None:
         urlconf = get_urlconf()
-    resolver = get_resolver(urlconf)
-    args = args or []
+
+    dispatcher = get_dispatcher(urlconf)
+    args = args or ()
     kwargs = kwargs or {}
 
-    prefix = get_script_prefix()
+    views = dispatcher.get_views(viewname, current_app)
+    return dispatcher.reverse(views, *args, **kwargs)
 
-    if not isinstance(viewname, six.string_types):
-        view = viewname
-    else:
-        parts = viewname.split(':')
-        parts.reverse()
-        view = parts[0]
-        path = parts[1:]
-
-        if current_app:
-            current_path = current_app.split(':')
-            current_path.reverse()
-        else:
-            current_path = None
-
-        resolved_path = []
-        ns_pattern = ''
-        while path:
-            ns = path.pop()
-            current_ns = current_path.pop() if current_path else None
-            # Lookup the name to see if it could be an app identifier.
-            try:
-                app_list = resolver.app_dict[ns]
-                # Yes! Path part matches an app in the current Resolver.
-                if current_ns and current_ns in app_list:
-                    # If we are reversing for a particular app, use that
-                    # namespace.
-                    ns = current_ns
-                elif ns not in app_list:
-                    # The name isn't shared by one of the instances (i.e.,
-                    # the default) so pick the first instance as the default.
-                    ns = app_list[0]
-            except KeyError:
-                pass
-
-            if ns != current_ns:
-                current_path = None
-
-            try:
-                extra, resolver = resolver.namespace_dict[ns]
-                resolved_path.append(ns)
-                ns_pattern = ns_pattern + extra
-            except KeyError as key:
-                if resolved_path:
-                    raise NoReverseMatch(
-                        "%s is not a registered namespace inside '%s'" %
-                        (key, ':'.join(resolved_path))
-                    )
-                else:
-                    raise NoReverseMatch("%s is not a registered namespace" % key)
-        if ns_pattern:
-            resolver = get_ns_resolver(ns_pattern, resolver)
-
-    return force_text(iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs)))
 
 reverse_lazy = lazy(reverse, six.text_type)
 
 
 def clear_url_caches():
     get_callable.cache_clear()
-    get_resolver.cache_clear()
-    get_ns_resolver.cache_clear()
+    get_dispatcher.cache_clear()
 
 
 def set_script_prefix(prefix):
@@ -144,40 +90,31 @@ def get_urlconf(default=None):
     Return the root URLconf to use for the current thread if it has been
     changed from the default one.
     """
+    if default is None:
+        from django.conf import settings
+        default = settings.ROOT_URLCONF
     return getattr(_urlconfs, "value", default)
 
 
-def is_valid_path(path, urlconf=None):
+def is_valid_path(path, urlconf=None, request=None):
     """
-    Return True if the given path resolves against the default URL resolver,
-    False otherwise. This is a convenience method to make working with "is
-    this a match?" cases easier, avoiding try...except blocks.
+    Returns True if the given path resolves against the default URL resolver,
+    False otherwise.
+
+    This is a convenience method to make working with "is this a match?" cases
+    easier, avoiding unnecessarily indented try...except blocks.
     """
-    try:
-        resolve(path, urlconf)
-        return True
-    except Resolver404:
-        return False
+    if urlconf is None:
+        urlconf = get_urlconf()
+    dispatcher = get_dispatcher(urlconf)
+    return dispatcher.is_valid_path(path, request)
 
 
-def translate_url(url, lang_code):
+def translate_url(url, lang_code, request=None):
     """
     Given a URL (absolute or relative), try to get its translated version in
     the `lang_code` language (either by i18n_patterns or by translated regex).
     Return the original URL if no translated version is found.
     """
-    parsed = urlsplit(url)
-    try:
-        match = resolve(parsed.path)
-    except Resolver404:
-        pass
-    else:
-        to_be_reversed = "%s:%s" % (match.namespace, match.url_name) if match.namespace else match.url_name
-        with override(lang_code):
-            try:
-                url = reverse(to_be_reversed, args=match.args, kwargs=match.kwargs)
-            except NoReverseMatch:
-                pass
-            else:
-                url = urlunsplit((parsed.scheme, parsed.netloc, url, parsed.query, parsed.fragment))
-    return url
+    dispatcher = get_dispatcher(get_urlconf())
+    return dispatcher.translate_url(url, lang_code, request)

--- a/django/urls/constraints.py
+++ b/django/urls/constraints.py
@@ -1,0 +1,167 @@
+from __future__ import unicode_literals
+
+import re
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
+from django.utils.encoding import force_text
+from django.utils.functional import cached_property
+from django.utils.regex_helper import normalize
+from django.utils.translation import get_language
+
+from .exceptions import NoReverseMatch, Resolver404
+
+
+class Constraint(object):
+    def describe(self, url_object):
+        """
+        Return a concise description to be used as an error message.
+        """
+        raise NotImplementedError("Constraint subclasses must implement describe()")
+
+    def match(self, path, request=None):
+        """
+        If this constraint matches, return (new_path, args, kwargs).
+        Otherwise, raise a Resolver404.
+        """
+        raise NotImplementedError("Constraint subclasses must implement match()")
+
+    def construct(self, url_object, *args, **kwargs):
+        """
+        (Partially) reconstruct url_object based on args and kwargs.
+        Return (url_object, leftover_args, leftover_kwargs).
+        Raise NoReverseMatch if the url cannot be reconstructed with these
+        arguments.
+        """
+        raise NotImplementedError("Constraint subclasses must implement construct()")
+
+
+class RegexPattern(Constraint):
+    def __init__(self, regex):
+        self._regex = force_text(regex)
+
+    def __repr__(self):
+        return '<RegexPattern regex=%r>' % self._regex
+
+    def describe(self, url_object):
+        pattern = self.regex.pattern
+        if url_object.path and pattern.startswith('^'):
+            pattern = pattern[1:]
+        url_object.path += pattern
+        return url_object
+
+    @cached_property
+    def regex(self):
+        try:
+            compiled_regex = re.compile(self._regex, re.UNICODE)
+        except re.error as e:
+            raise ImproperlyConfigured(
+                '"%s" is not a valid regular expression: %s' %
+                (self._regex, six.text_type(e)))
+        return compiled_regex
+
+    @cached_property
+    def normalized_patterns(self):
+        return normalize(self.regex.pattern)
+
+    def match(self, path, request=None):
+        match = self.regex.search(path)
+        if match:
+            kwargs = match.groupdict()
+            args = match.groups() if not kwargs else ()
+            new_path = path[match.end():]
+            return new_path, args, kwargs
+        raise Resolver404()
+
+    def construct(self, url_object, *args, **kwargs):
+        for pattern, params in reversed(self.normalized_patterns):
+            if args:
+                if len(params) > len(args):
+                    continue
+                subs = dict(zip(params, args))
+                new_args = args[len(params):]
+                new_kwargs = kwargs
+            elif kwargs:
+                if any(param not in kwargs for param in params):
+                    continue
+                subs = kwargs
+                new_args = ()
+                new_kwargs = {k: v for (k, v) in kwargs.items() if k not in params}
+            elif params:
+                continue
+            else:
+                subs, new_args, new_kwargs = {}, (), {}
+            path = pattern % subs
+            if self.regex.search(path):
+                url_object.path += path
+                return url_object, new_args, new_kwargs
+        raise NoReverseMatch()
+
+
+class LocalizedRegexPattern(RegexPattern):
+    def __init__(self, regex):
+        self._regex = regex
+        self._regex_dict = {}
+        self._normalized_dict = {}
+
+    @property
+    def regex(self):
+        language_code = get_language()
+        if language_code not in self._regex_dict:
+            if isinstance(self._regex, six.string_types):
+                regex = self._regex
+            else:
+                regex = force_text(self._regex)
+            try:
+                compiled_regex = re.compile(regex, re.UNICODE)
+            except re.error as e:
+                raise ImproperlyConfigured(
+                    '"%s" is not a valid regular expression: %s' %
+                    (regex, six.text_type(e)))
+
+            self._regex_dict[language_code] = compiled_regex
+        return self._regex_dict[language_code]
+
+    @property
+    def normalized_patterns(self):
+        language_code = get_language()
+        if language_code not in self._normalized_dict:
+            self._normalized_dict[language_code] = normalize(self.regex.pattern)
+        return self._normalized_dict[language_code]
+
+
+class LocalePrefix(LocalizedRegexPattern):
+    def __init__(self, prefix_default_language=True):
+        super(LocalePrefix, self).__init__('')
+        self.prefix_default_language = prefix_default_language
+
+    @property
+    def regex(self):
+        language_code = get_language() or settings.LANGUAGE_CODE
+        if language_code not in self._regex_dict:
+            if language_code == settings.LANGUAGE_CODE and not self.prefix_default_language:
+                regex_string = ''
+            else:
+                regex_string = r'^%s/' % language_code
+            self._regex_dict[language_code] = re.compile(regex_string, re.UNICODE)
+        return self._regex_dict[language_code]
+
+
+class ScriptPrefix(Constraint):
+    def __repr__(self):
+        return '<ScriptPrefix>'
+
+    def describe(self, url_object):
+        return url_object
+
+    def match(self, path, request=None):
+        if not path.startswith('/'):
+            raise Resolver404()
+        return path[1:], (), {}
+
+    def construct(self, url_object, *args, **kwargs):
+        from django.urls import get_script_prefix
+
+        url_object.path = get_script_prefix()
+        return url_object, args, kwargs

--- a/django/urls/dispatcher.py
+++ b/django/urls/dispatcher.py
@@ -1,0 +1,281 @@
+from __future__ import unicode_literals
+
+from collections import OrderedDict, defaultdict
+from importlib import import_module
+
+from django.conf import urls
+from django.conf.urls import URLConf, URLPattern
+from django.template.context import BaseContext
+from django.utils import lru_cache, six
+from django.utils.encoding import force_text
+from django.utils.functional import cached_property
+from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
+from django.utils.translation import override
+
+from .constraints import ScriptPrefix
+from .exceptions import NoReverseMatch, Resolver404
+from .resolvers import Resolver
+from .utils import URL, describe_constraints, get_callable, get_lookup_string
+
+
+@lru_cache.lru_cache(maxsize=None)
+def get_dispatcher(urlconf):
+    return Dispatcher(urlconf)
+
+
+class Dispatcher(object):
+    def __init__(self, urlconf):
+        self.urlconf_name = urlconf
+        root_pattern = URLPattern([ScriptPrefix()], URLConf(urlconf))
+        self.resolver = Resolver(root_pattern)
+        self.reverser = Namespace(root_pattern, root_pattern.constraints)
+
+    def __repr__(self):
+        return "<Dispatcher '%s'>" % self.urlconf_name
+
+    def get_views(self, lookup, current_app=None):
+        if isinstance(lookup, six.string_types):
+            lookup = lookup.split(':')
+        elif lookup:
+            lookup = [lookup]
+        else:
+            raise NoReverseMatch("View name must not be empty; got '%s'" % (lookup,))
+
+        if current_app:
+            current_app = current_app.split(':')
+
+        try:
+            return self.reverser.get_views(lookup, current_app)
+        except KeyError:
+            pass
+        raise NoReverseMatch(self.reverser.get_error_message(lookup))
+
+    def reverse(self, views, *args, **kwargs):
+        for view in views:
+            try:
+                url = view.reverse(*args, **kwargs)
+            except NoReverseMatch:
+                pass
+            else:
+                return six.text_type(url)
+
+        raise NoReverseMatch(
+            "Reverse for '%s' with arguments '%s' and keyword "
+            "arguments '%s' not found. %d pattern(s) tried: %s" %
+            (
+                views[0].url_name, args, kwargs, len(views),
+                [str(describe_constraints(view.constraints)) for view in views],
+            )
+        )
+
+    @cached_property
+    def urlconf_module(self):
+        if isinstance(self.urlconf_name, six.string_types):
+            return import_module(self.urlconf_name)
+        else:
+            return self.urlconf_name
+
+    def resolve(self, path, request=None):
+        return next(self.resolver.resolve(path, request))
+
+    def resolve_error_handler(self, view_type):
+        callback = getattr(self.urlconf_module, 'handler%s' % view_type, None)
+        if not callback:
+            # No handler specified in file; use default
+            callback = getattr(urls, 'handler%s' % view_type)
+        return get_callable(callback), {}
+
+    def is_valid_path(self, path, request=None):
+        """
+        Returns True if the given path resolves against the default URL resolver,
+        False otherwise.
+
+        This is a convenience method to make working with "is this a match?" cases
+        easier, avoiding unnecessarily indented try...except blocks.
+        """
+        try:
+            self.resolve(path, request)
+            return True
+        except Resolver404:
+            return False
+
+    def translate_url(self, url, lang_code, request=None):
+        """
+        Given a URL (absolute or relative), try to get its translated version in
+        the `lang_code` language (either by i18n_patterns or by translated regex).
+        Return the original URL if no translated version is found.
+        """
+        parsed = urlsplit(url)
+        try:
+            match = self.resolve(parsed.path, request=request)
+        except Resolver404:
+            pass
+        else:
+            to_be_reversed = "%s:%s" % (match.namespace, match.url_name) if match.namespace else match.url_name
+            with override(lang_code):
+                try:
+                    views = self.get_views(to_be_reversed)
+                    url = self.reverse(views, *match.args, **match.kwargs)
+                except NoReverseMatch:
+                    pass
+                else:
+                    url = urlunsplit((parsed.scheme, parsed.netloc, url, parsed.query, parsed.fragment))
+        return url
+
+    @cached_property
+    def _callbacks(self):
+        return {get_lookup_string(view) for view in self.reverser.views if callable(view)}
+
+    def is_callback(self, view):
+        return view in self._callbacks
+
+
+class Namespace(object):
+    def __init__(self, urlpattern, constraints=None, kwargs=None):
+        self.urlconf = urlpattern.target
+        self.namespace = urlpattern.target.namespace
+        self.app_name = urlpattern.target.app_name or urlpattern.target.namespace
+        self.constraints = constraints or []
+        self.kwargs = kwargs or {}
+
+    def __repr__(self):
+        return "<%s '%s' [app_name='%s']>" % (
+            self.__class__.__name__, self.urlconf.namespace,
+            self.urlconf.app_name,
+        )
+
+    def __getitem__(self, item):
+        try:
+            return self.namespaces[item]
+        except KeyError:
+            return self.views[item]
+
+    def get_error_message(self, lookup):
+        if len(lookup) == 1:
+            msg = "'%s' is not a registered view name" % lookup[0]
+        else:
+            msg = "'%s' is not a registered namespace" % lookup[0]
+        if self.app_name:
+            msg += " inside '%s'" % self.app_name
+        return msg
+
+    def get_views(self, lookup, current_app=None):
+        name = lookup[0]
+        if len(lookup) == 1:
+            return self.views[name]
+
+        current = current_app.pop(0) if current_app else None
+        app_name = self.app_dict.get(name, name)
+        options = self.namespace_dict[app_name]
+        if current and current in options:
+            try:
+                return self.namespaces[current].get_views(lookup[1:], current_app)
+            except KeyError:
+                pass
+            raise NoReverseMatch(self.get_error_message(lookup))
+
+        if name == app_name and name not in options:
+            name = options[0]
+
+        try:
+            return self.namespaces[name].get_views(lookup[1:])
+        except KeyError:
+            pass
+        raise NoReverseMatch(self.get_error_message(lookup))
+
+    @cached_property
+    def views(self):
+        def get_views_recursive(urlpatterns, constraints, kwargs):
+            views = defaultdict(list)
+            for urlpattern in reversed(urlpatterns):
+                constraints = constraints + urlpattern.constraints
+                kwargs.push(urlpattern.target.kwargs)
+                if urlpattern.is_endpoint():
+                    view = View(urlpattern, list(constraints), kwargs.flatten())
+                    views[urlpattern.target.view].append(view)
+                    if urlpattern.target.url_name:
+                        views[urlpattern.target.url_name].append(view)
+                elif not urlpattern.target.namespace:
+                    for key, value in get_views_recursive(urlpattern.target.urlpatterns, constraints, kwargs).items():
+                        views[key].extend(value)
+                constraints = constraints[:-len(urlpattern.constraints)]
+                kwargs.pop()
+            return views
+
+        default_kwargs = BaseContext()
+        default_kwargs.dicts[0] = self.kwargs
+        return dict(get_views_recursive(self.urlconf.urlpatterns, self.constraints, default_kwargs))
+
+    @cached_property
+    def namespaces(self):
+        def get_namespaces_recursive(urlpatterns, constraints, kwargs):
+            # We need to preserve the order to get the correct default
+            # namespace in namespace_dict.
+            namespaces = OrderedDict()
+            for urlpattern in reversed(urlpatterns):
+                if not urlpattern.is_endpoint():
+                    constraints = constraints + urlpattern.constraints
+                    kwargs.push(urlpattern.target.kwargs)
+                    if urlpattern.target.namespace:
+                        namespaces[urlpattern.target.namespace] = Namespace(
+                            urlpattern, list(constraints),
+                            kwargs.flatten(),
+                        )
+                    else:
+                        namespaces.update(
+                            get_namespaces_recursive(urlpattern.target.urlpatterns, constraints, kwargs),
+                        )
+                    constraints = constraints[:-len(urlpattern.constraints)]
+                    kwargs.pop()
+            return namespaces
+
+        default_kwargs = BaseContext()
+        default_kwargs.dicts[0] = self.kwargs
+        return get_namespaces_recursive(self.urlconf.urlpatterns, self.constraints, default_kwargs)
+
+    @cached_property
+    def namespace_dict(self):
+        app_dict = defaultdict(list)
+        for namespace in self.namespaces.values():
+            app_dict[namespace.app_name].append(namespace.namespace)
+        return dict(app_dict)
+
+    @cached_property
+    def app_dict(self):
+        return {
+            namespace.namespace: namespace.app_name
+            for namespace in self.namespaces.values()
+        }
+
+
+class View(object):
+    def __init__(self, urlpattern, constraints=None, kwargs=None):
+        self.endpoint = urlpattern.target
+        self.url_name = urlpattern.target.url_name
+        self.constraints = constraints or []
+        self.kwargs = kwargs or {}
+
+    def __repr__(self):
+        return "<%s %s%s>" % (
+            self.__class__.__name__, describe_constraints(self.constraints),
+            (" [name='%s']" % self.url_name) if self.url_name else '',
+        )
+
+    def reverse(self, *args, **kwargs):
+        text_args = [force_text(x) for x in args]
+        text_kwargs = {k: force_text(v) for k, v in kwargs.items()}
+
+        url = URL()
+        new_args, new_kwargs = text_args, text_kwargs
+        for constraint in self.constraints:
+            url, new_args, new_kwargs = constraint.construct(url, *new_args, **new_kwargs)
+        if new_kwargs:
+            if any(name not in self.kwargs for name in new_kwargs):
+                raise NoReverseMatch()
+            for k, v in self.kwargs.items():
+                if kwargs.get(k, v) != v:
+                    raise NoReverseMatch(self.constraints)
+        if new_args:
+            raise NoReverseMatch(self.constraints)
+
+        return six.text_type(url)

--- a/django/urls/exceptions.py
+++ b/django/urls/exceptions.py
@@ -1,11 +1,42 @@
 from __future__ import unicode_literals
 
+import itertools
+
 from django.http import Http404
+
+from .utils import describe_constraints
 
 
 class Resolver404(Http404):
-    pass
+    """
+    Raised when an url cannot be resolved to a view.
+    """
+    @property
+    def path(self):
+        if self.args:
+            return self.args[0].get('path', '')
+        return ''
+
+    @property
+    def tried(self):
+        if self.args:
+            return self.args[0].get('tried', [])
+        return []
+
+    @property
+    def tried_patterns(self):
+        patterns = []
+        for resolvers in self.tried:
+            pattern = describe_constraints(itertools.chain.from_iterable(r.constraints for r in resolvers))
+            url_name = getattr(resolvers[-1], 'url_name', None)
+            if url_name:
+                pattern += ' [name=%s]' % url_name
+            patterns.append(pattern)
+        return patterns
 
 
 class NoReverseMatch(Exception):
+    """
+    Raised when reverse() cannot reconstruct a valid url.
+    """
     pass

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -7,50 +7,68 @@ attributes of the resolved URL match.
 """
 from __future__ import unicode_literals
 
-import functools
-import re
-from importlib import import_module
+from functools import update_wrapper
+from types import ModuleType
 
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-from django.utils import lru_cache, six
-from django.utils.datastructures import MultiValueDict
-from django.utils.encoding import force_str, force_text
+from django.utils.decorators import available_attrs
 from django.utils.functional import cached_property
-from django.utils.http import RFC3986_SUBDELIMS, urlquote
-from django.utils.regex_helper import normalize
-from django.utils.translation import get_language
 
-from .exceptions import NoReverseMatch, Resolver404
-from .utils import get_callable
+from .exceptions import Resolver404
+from .utils import get_lookup_string
 
 
 class ResolverMatch(object):
-    def __init__(self, func, args, kwargs, url_name=None, app_names=None, namespaces=None):
-        self.func = func
+    def __init__(self, endpoint, args, kwargs, app_names=None, namespaces=None):
+        self.endpoint = endpoint
         self.args = args
         self.kwargs = kwargs
-        self.url_name = url_name
+        self.app_names = app_names or []
+        self.namespaces = namespaces or []
 
-        # If a URLRegexResolver doesn't have a namespace or app_name, it passes
-        # in an empty value.
-        self.app_names = [x for x in app_names if x] if app_names else []
-        self.app_name = ':'.join(self.app_names)
-        self.namespaces = [x for x in namespaces if x] if namespaces else []
-        self.namespace = ':'.join(self.namespaces)
+    @cached_property
+    def func(self):
+        return self.endpoint.func
 
-        if not hasattr(func, '__name__'):
-            # A class-based view
-            self._func_path = '.'.join([func.__class__.__module__, func.__class__.__name__])
-        else:
-            # A function-based view
-            self._func_path = '.'.join([func.__module__, func.__name__])
+    @cached_property
+    def callback(self):
+        return getattr(self.endpoint, 'callback', self.func)
 
-        view_path = url_name or self._func_path
-        self.view_name = ':'.join(self.namespaces + [view_path])
+    @cached_property
+    def url_name(self):
+        return getattr(self.endpoint, 'url_name', None)
+
+    @cached_property
+    def _func_path(self):
+        if hasattr(self.endpoint, 'lookup_str'):
+            return self.endpoint.lookup_str
+
+        return get_lookup_string(self.func)
+
+    @cached_property
+    def app_name(self):
+        """
+        Return the fully qualified application namespace.
+        """
+        return ':'.join(self.app_names)
+
+    @cached_property
+    def namespace(self):
+        """
+        Return the fully qualified instance namespace.
+        """
+        return ':'.join(self.namespaces)
+
+    @cached_property
+    def view_name(self):
+        """
+        Return the fully qualified view name, consisting of the instance
+        namespace and the view's name.
+        """
+        view_name = self.url_name or self._func_path
+        return ':'.join(self.namespaces + [view_name])
 
     def __getitem__(self, index):
-        return (self.func, self.args, self.kwargs)[index]
+        return (self.callback, self.args, self.kwargs)[index]
 
     def __repr__(self):
         return "ResolverMatch(func=%s, args=%s, kwargs=%s, url_name=%s, app_names=%s, namespaces=%s)" % (
@@ -58,346 +76,109 @@ class ResolverMatch(object):
             self.app_names, self.namespaces,
         )
 
-
-@lru_cache.lru_cache(maxsize=None)
-def get_resolver(urlconf=None):
-    if urlconf is None:
-        from django.conf import settings
-        urlconf = settings.ROOT_URLCONF
-    return RegexURLResolver(r'^/', urlconf)
-
-
-@lru_cache.lru_cache(maxsize=None)
-def get_ns_resolver(ns_pattern, resolver):
-    # Build a namespaced resolver for the given parent URLconf pattern.
-    # This makes it possible to have captured parameters in the parent
-    # URLconf pattern.
-    ns_resolver = RegexURLResolver(ns_pattern, resolver.url_patterns)
-    return RegexURLResolver(r'^/', [ns_resolver])
-
-
-class LocaleRegexProvider(object):
-    """
-    A mixin to provide a default regex property which can vary by active
-    language.
-    """
-    def __init__(self, regex):
-        # regex is either a string representing a regular expression, or a
-        # translatable string (using ugettext_lazy) representing a regular
-        # expression.
-        self._regex = regex
-        self._regex_dict = {}
-
-    @property
-    def regex(self):
+    @classmethod
+    def from_submatch(cls, submatch, args, kwargs, app_name=None, namespace=None):
         """
-        Return a compiled regular expression based on the activate language.
+        Create a new ResolverMatch, carrying over any properties from
+        submatch. Does not carry over args if there are any kwargs.
         """
-        language_code = get_language()
-        if language_code not in self._regex_dict:
-            regex = self._regex if isinstance(self._regex, six.string_types) else force_text(self._regex)
-            try:
-                compiled_regex = re.compile(regex, re.UNICODE)
-            except re.error as e:
-                raise ImproperlyConfigured(
-                    '"%s" is not a valid regular expression: %s' %
-                    (regex, six.text_type(e))
-                )
-            self._regex_dict[language_code] = compiled_regex
-        return self._regex_dict[language_code]
+        if kwargs or submatch.kwargs:
+            args = submatch.args
+            kwargs.update(submatch.kwargs)
+        else:
+            args += submatch.args
+        app_names = ([app_name] if app_name else []) + submatch.app_names
+        namespaces = ([namespace] if namespace else []) + submatch.namespaces
+        return cls(submatch.endpoint, args, kwargs, app_names, namespaces)
 
 
-class RegexURLPattern(LocaleRegexProvider):
-    def __init__(self, regex, callback, default_args=None, name=None):
-        LocaleRegexProvider.__init__(self, regex)
-        self.callback = callback  # the view
-        self.default_args = default_args or {}
-        self.name = name
+class BaseResolver(object):
+    def __init__(self, urlpattern, decorators=None):
+        self.constraints = list(urlpattern.constraints)
+        self.kwargs = urlpattern.target.kwargs.copy()
+        self.decorators = list(decorators or [])
+        self.decorators.extend(urlpattern.target.decorators)
+
+    def resolve(self, path, request):
+        raise NotImplementedError("Subclasses of 'BaseResolver' must implement the 'resolve' method.")
+
+    def match(self, path, request):
+        args, kwargs = (), {}
+        for constraint in self.constraints:
+            path, new_args, new_kwargs = constraint.match(path, request)
+            args += new_args
+            kwargs.update(new_kwargs)
+        kwargs.update(self.kwargs)
+        return path, args, kwargs
+
+
+class Resolver(BaseResolver):
+    def __init__(self, urlpattern, *args, **kwargs):
+        super(Resolver, self).__init__(urlpattern, *args, **kwargs)
+        self.urlconf = urlpattern.target
+        self.namespace = urlpattern.target.namespace
+        self.app_name = urlpattern.target.app_name
 
     def __repr__(self):
-        return force_str('<%s %s %s>' % (self.__class__.__name__, self.name, self.regex.pattern))
-
-    def resolve(self, path):
-        match = self.regex.search(path)
-        if match:
-            # If there are any named groups, use those as kwargs, ignoring
-            # non-named groups. Otherwise, pass all non-named arguments as
-            # positional arguments.
-            kwargs = match.groupdict()
-            args = () if kwargs else match.groups()
-            # In both cases, pass any extra_kwargs as **kwargs.
-            kwargs.update(self.default_args)
-            return ResolverMatch(self.callback, args, kwargs, self.name)
-
-    @cached_property
-    def lookup_str(self):
-        """
-        A string that identifies the view (e.g. 'path.to.view_function' or
-        'path.to.ClassBasedView').
-        """
-        callback = self.callback
-        # Python 3.5 collapses nested partials, so can change "while" to "if"
-        # when it's the minimum supported version.
-        while isinstance(callback, functools.partial):
-            callback = callback.func
-        if not hasattr(callback, '__name__'):
-            return callback.__module__ + "." + callback.__class__.__name__
+        urlconf_name = self.urlconf.urlconf_name
+        if isinstance(urlconf_name, (list, tuple)) and len(urlconf_name):
+            urlconf_repr = '<%s list>' % self.resolvers[0].__class__.__name__
+        elif isinstance(urlconf_name, ModuleType):
+            urlconf_repr = repr(urlconf_name.__name__)
         else:
-            return callback.__module__ + "." + callback.__name__
-
-
-class RegexURLResolver(LocaleRegexProvider):
-    def __init__(self, regex, urlconf_name, default_kwargs=None, app_name=None, namespace=None):
-        LocaleRegexProvider.__init__(self, regex)
-        # urlconf_name is the dotted Python path to the module defining
-        # urlpatterns. It may also be an object with an urlpatterns attribute
-        # or urlpatterns itself.
-        self.urlconf_name = urlconf_name
-        self.callback = None
-        self.default_kwargs = default_kwargs or {}
-        self.namespace = namespace
-        self.app_name = app_name
-        self._reverse_dict = {}
-        self._namespace_dict = {}
-        self._app_dict = {}
-        # set of dotted paths to all functions and classes that are used in
-        # urlpatterns
-        self._callback_strs = set()
-        self._populated = False
-
-    def __repr__(self):
-        if isinstance(self.urlconf_name, list) and len(self.urlconf_name):
-            # Don't bother to output the whole list, it can be huge
-            urlconf_repr = '<%s list>' % self.urlconf_name[0].__class__.__name__
-        else:
-            urlconf_repr = repr(self.urlconf_name)
-        return str('<%s %s (%s:%s) %s>') % (
-            self.__class__.__name__, urlconf_repr, self.app_name,
-            self.namespace, self.regex.pattern,
+            urlconf_repr = repr(urlconf_name)
+        return "<%s %s%s>" % (
+            self.__class__.__name__, urlconf_repr,
+            ("[app_name='%s']" % self.app_name) if self.app_name else '',
         )
 
-    def _populate(self):
-        lookups = MultiValueDict()
-        namespaces = {}
-        apps = {}
-        language_code = get_language()
-        for pattern in reversed(self.url_patterns):
-            if isinstance(pattern, RegexURLPattern):
-                self._callback_strs.add(pattern.lookup_str)
-            p_pattern = pattern.regex.pattern
-            if p_pattern.startswith('^'):
-                p_pattern = p_pattern[1:]
-            if isinstance(pattern, RegexURLResolver):
-                if pattern.namespace:
-                    namespaces[pattern.namespace] = (p_pattern, pattern)
-                    if pattern.app_name:
-                        apps.setdefault(pattern.app_name, []).append(pattern.namespace)
-                else:
-                    parent_pat = pattern.regex.pattern
-                    for name in pattern.reverse_dict:
-                        for matches, pat, defaults in pattern.reverse_dict.getlist(name):
-                            new_matches = normalize(parent_pat + pat)
-                            lookups.appendlist(
-                                name,
-                                (
-                                    new_matches,
-                                    p_pattern + pat,
-                                    dict(defaults, **pattern.default_kwargs),
-                                )
-                            )
-                    for namespace, (prefix, sub_pattern) in pattern.namespace_dict.items():
-                        namespaces[namespace] = (p_pattern + prefix, sub_pattern)
-                    for app_name, namespace_list in pattern.app_dict.items():
-                        apps.setdefault(app_name, []).extend(namespace_list)
-                    self._callback_strs.update(pattern._callback_strs)
-            else:
-                bits = normalize(p_pattern)
-                lookups.appendlist(pattern.callback, (bits, p_pattern, pattern.default_args))
-                if pattern.name is not None:
-                    lookups.appendlist(pattern.name, (bits, p_pattern, pattern.default_args))
-        self._reverse_dict[language_code] = lookups
-        self._namespace_dict[language_code] = namespaces
-        self._app_dict[language_code] = apps
-        self._populated = True
+    @cached_property
+    def resolvers(self):
+        return [
+            urlpattern.as_resolver(decorators=self.decorators)
+            for urlpattern in self.urlconf.urlpatterns
+        ]
 
-    @property
-    def reverse_dict(self):
-        language_code = get_language()
-        if language_code not in self._reverse_dict:
-            self._populate()
-        return self._reverse_dict[language_code]
+    def resolve(self, path, request=None):
+        new_path, args, kwargs = self.match(path, request)
 
-    @property
-    def namespace_dict(self):
-        language_code = get_language()
-        if language_code not in self._namespace_dict:
-            self._populate()
-        return self._namespace_dict[language_code]
-
-    @property
-    def app_dict(self):
-        language_code = get_language()
-        if language_code not in self._app_dict:
-            self._populate()
-        return self._app_dict[language_code]
-
-    def _is_callback(self, name):
-        if not self._populated:
-            self._populate()
-        return name in self._callback_strs
-
-    def resolve(self, path):
-        path = force_text(path)  # path may be a reverse_lazy object
         tried = []
-        match = self.regex.search(path)
-        if match:
-            new_path = path[match.end():]
-            for pattern in self.url_patterns:
-                try:
-                    sub_match = pattern.resolve(new_path)
-                except Resolver404 as e:
-                    sub_tried = e.args[0].get('tried')
-                    if sub_tried is not None:
-                        tried.extend([pattern] + t for t in sub_tried)
-                    else:
-                        tried.append([pattern])
+        for resolver in self.resolvers:
+            try:
+                for match in resolver.resolve(new_path, request):
+                    yield ResolverMatch.from_submatch(match, args, kwargs, self.app_name, self.namespace)
+                tried.append([resolver])
+            except Resolver404 as e:
+                if e.tried:
+                    tried.extend([resolver] + t for t in e.tried)
                 else:
-                    if sub_match:
-                        # Merge captured arguments in match with submatch
-                        sub_match_dict = dict(match.groupdict(), **self.default_kwargs)
-                        sub_match_dict.update(sub_match.kwargs)
+                    tried.append([resolver])
+        raise Resolver404({'path': new_path, 'tried': tried})
 
-                        # If there are *any* named groups, ignore all non-named groups.
-                        # Otherwise, pass all non-named arguments as positional arguments.
-                        sub_match_args = sub_match.args
-                        if not sub_match_dict:
-                            sub_match_args = match.groups() + sub_match.args
 
-                        return ResolverMatch(
-                            sub_match.func,
-                            sub_match_args,
-                            sub_match_dict,
-                            sub_match.url_name,
-                            [self.app_name] + sub_match.app_names,
-                            [self.namespace] + sub_match.namespaces,
-                        )
-                    tried.append([pattern])
-            raise Resolver404({'tried': tried, 'path': new_path})
-        raise Resolver404({'path': path})
+class ResolverEndpoint(BaseResolver):
+    def __init__(self, urlpattern, *args, **kwargs):
+        super(ResolverEndpoint, self).__init__(urlpattern, *args, **kwargs)
+        self.func = urlpattern.target.view
+        self.lookup_str = urlpattern.target.lookup_str
+        self.url_name = urlpattern.target.url_name
 
-    @cached_property
-    def urlconf_module(self):
-        if isinstance(self.urlconf_name, six.string_types):
-            return import_module(self.urlconf_name)
-        else:
-            return self.urlconf_name
-
-    @cached_property
-    def url_patterns(self):
-        # urlconf_module might be a valid set of patterns, so we default to it
-        patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
-        try:
-            iter(patterns)
-        except TypeError:
-            msg = (
-                "The included URLconf '{name}' does not appear to have any "
-                "patterns in it. If you see valid patterns in the file then "
-                "the issue is probably caused by a circular import."
-            )
-            raise ImproperlyConfigured(msg.format(name=self.urlconf_name))
-        return patterns
-
-    def resolve_error_handler(self, view_type):
-        callback = getattr(self.urlconf_module, 'handler%s' % view_type, None)
-        if not callback:
-            # No handler specified in file; use lazy import, since
-            # django.conf.urls imports this file.
-            from django.conf import urls
-            callback = getattr(urls, 'handler%s' % view_type)
-        return get_callable(callback), {}
-
-    def _reverse_with_prefix(self, lookup_view, _prefix, *args, **kwargs):
-        if args and kwargs:
-            raise ValueError("Don't mix *args and **kwargs in call to reverse()!")
-        text_args = [force_text(v) for v in args]
-        text_kwargs = {k: force_text(v) for (k, v) in kwargs.items()}
-
-        if not self._populated:
-            self._populate()
-
-        possibilities = self.reverse_dict.getlist(lookup_view)
-
-        for possibility, pattern, defaults in possibilities:
-            for result, params in possibility:
-                if args:
-                    if len(args) != len(params):
-                        continue
-                    candidate_subs = dict(zip(params, text_args))
-                else:
-                    if (set(kwargs.keys()) | set(defaults.keys()) != set(params) |
-                            set(defaults.keys())):
-                        continue
-                    matches = True
-                    for k, v in defaults.items():
-                        if kwargs.get(k, v) != v:
-                            matches = False
-                            break
-                    if not matches:
-                        continue
-                    candidate_subs = text_kwargs
-                # WSGI provides decoded URLs, without %xx escapes, and the URL
-                # resolver operates on such URLs. First substitute arguments
-                # without quoting to build a decoded URL and look for a match.
-                # Then, if we have a match, redo the substitution with quoted
-                # arguments in order to return a properly encoded URL.
-                candidate_pat = _prefix.replace('%', '%%') + result
-                if re.search('^%s%s' % (re.escape(_prefix), pattern), candidate_pat % candidate_subs, re.UNICODE):
-                    # safe characters from `pchar` definition of RFC 3986
-                    url = urlquote(candidate_pat % candidate_subs, safe=RFC3986_SUBDELIMS + str('/~:@'))
-                    # Don't allow construction of scheme relative urls.
-                    if url.startswith('//'):
-                        url = '/%%2F%s' % url[2:]
-                    return url
-        # lookup_view can be URL name or callable, but callables are not
-        # friendly in error messages.
-        m = getattr(lookup_view, '__module__', None)
-        n = getattr(lookup_view, '__name__', None)
-        if m is not None and n is not None:
-            lookup_view_s = "%s.%s" % (m, n)
-        else:
-            lookup_view_s = lookup_view
-
-        patterns = [pattern for (possibility, pattern, defaults) in possibilities]
-        raise NoReverseMatch(
-            "Reverse for '%s' with arguments '%s' and keyword "
-            "arguments '%s' not found. %d pattern(s) tried: %s" %
-            (lookup_view_s, args, kwargs, len(patterns), patterns)
+    def __repr__(self):
+        return "<%s '%s'%s>" % (
+            self.__class__.__name__, self.lookup_str,
+            (" [name='%s']" % self.url_name) if self.url_name else '',
         )
 
+    @cached_property
+    def callback(self):
+        if not self.decorators:
+            return self.func
+        callback = self.func
+        for decorator in reversed(self.decorators):
+            callback = decorator(callback)
+        update_wrapper(callback, self.func, assigned=available_attrs(self.func))
+        return callback
 
-class LocaleRegexURLResolver(RegexURLResolver):
-    """
-    A URL resolver that always matches the active language code as URL prefix.
-
-    Rather than taking a regex argument, we just override the ``regex``
-    function to always return the active language-code as regex.
-    """
-    def __init__(
-        self, urlconf_name, default_kwargs=None, app_name=None, namespace=None,
-        prefix_default_language=True,
-    ):
-        super(LocaleRegexURLResolver, self).__init__(
-            None, urlconf_name, default_kwargs, app_name, namespace,
-        )
-        self.prefix_default_language = prefix_default_language
-
-    @property
-    def regex(self):
-        language_code = get_language() or settings.LANGUAGE_CODE
-        if language_code not in self._regex_dict:
-            if language_code == settings.LANGUAGE_CODE and not self.prefix_default_language:
-                regex_string = ''
-            else:
-                regex_string = '^%s/' % language_code
-            self._regex_dict[language_code] = re.compile(regex_string, re.UNICODE)
-        return self._regex_dict[language_code]
+    def resolve(self, path, request=None):
+        new_path, args, kwargs = self.match(path, request)
+        yield ResolverMatch(self, args, kwargs)

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -43,7 +43,7 @@ def set_language(request):
         lang_code = request.POST.get(LANGUAGE_QUERY_PARAMETER)
         if lang_code and check_for_language(lang_code):
             if next:
-                next_trans = translate_url(next, lang_code)
+                next_trans = translate_url(next, lang_code, request)
                 if next_trans != next:
                     response = http.HttpResponseRedirect(next_trans)
             if hasattr(request, 'session'):

--- a/tests/admin_custom_urls/models.py
+++ b/tests/admin_custom_urls/models.py
@@ -30,7 +30,10 @@ class ActionAdmin(admin.ModelAdmin):
         Remove all entries named 'name' from the ModelAdmin instance URL
         patterns list
         """
-        return [url for url in super(ActionAdmin, self).get_urls() if url.name != name]
+        return [
+            url for url in super(ActionAdmin, self).get_urls()
+            if url.is_endpoint() and url.target.url_name != name
+        ]
 
     def get_urls(self):
         # Add the URL of our custom 'add_view' view to the front of the URLs

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -713,7 +713,10 @@ class UnchangeableObjectAdmin(admin.ModelAdmin):
     def get_urls(self):
         # Disable change_view, but leave other urls untouched
         urlpatterns = super(UnchangeableObjectAdmin, self).get_urls()
-        return [p for p in urlpatterns if p.name and not p.name.endswith("_change")]
+        return [
+            p for p in urlpatterns
+            if p.is_endpoint() and p.target.url_name and not p.target.url_name.endswith("_change")
+        ]
 
 
 def callable_on_unknown(obj):

--- a/tests/urlpatterns_reverse/namespace_urls.py
+++ b/tests/urlpatterns_reverse/namespace_urls.py
@@ -55,4 +55,9 @@ urlpatterns = [
     ),
 
     url(r'^\+\\\$\*/', include('urlpatterns_reverse.namespace_urls', namespace='special')),
+
+    # Keep this as the last entry
+    url(r'inline-patterns/', include([
+        url(r'^$', views.empty_view),
+    ])),
 ]

--- a/tests/urls_tests/decorators.py
+++ b/tests/urls_tests/decorators.py
@@ -1,0 +1,15 @@
+from __future__ import unicode_literals
+
+
+def outer_decorator(func):
+    def inner(*args, **kwargs):
+        return func(*args, **kwargs)
+    inner.decorated_by = 'outer'
+    return inner
+
+
+def inner_decorator(func):
+    def inner(*args, **kwargs):
+        return func(*args, **kwargs)
+    inner.decorated_by = 'inner'
+    return inner

--- a/tests/urls_tests/test_base.py
+++ b/tests/urls_tests/test_base.py
@@ -1,0 +1,2 @@
+# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/urls_tests/test_constraints.py
+++ b/tests/urls_tests/test_constraints.py
@@ -1,0 +1,84 @@
+# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals
+
+import re
+
+from django.test import SimpleTestCase
+from django.urls import URL, NoReverseMatch, RegexPattern, Resolver404
+
+regex_match_data = (
+    # format: (regex, url, new_url, captured_args, captured_kwargs)
+    (r'^$', '', ('', (), {})),
+    (r'^$', '/', Resolver404),
+    (r'^', '/', ('/', (), {})),
+    (r'^test/$', 'test/', ('', (), {})),
+    (r'^(?P<pk>\d+)/$', '15/', ('', (), {'pk': '15'})),
+    (r'^(\d+)/$', '42/', ('', ('42',), {})),
+    # Don't mix named and unnamed groups
+    (r'^([\w-]+)/(?P<pk>\d+)/$', 'test/37/', ('', (), {'pk': '37'})),
+
+    (r'^(?P<pk>\d+)/', '21/test/', ('test/', (), {'pk': '21'})),
+    (r'test/', 'some/prefix/test/trailing/', ('trailing/', (), {})),
+
+    # unicode characters
+    (r'^I ♥ Django/$', 'I ♥ Django/', ('', (), {})),
+)
+
+
+regex_construct_data = (
+    # format: (regex, args, kwargs, expected)
+    (r'^$', (), {}, ('', (), {})),
+    (r'^test/$', (), {}, ('test/', (), {})),
+    (r'test/', (), {}, ('test/', (), {})),
+    (r'^(\d+)/$', ('42',), {}, ('42/', (), {})),
+    (r'^(?P<pk>\d+)/$', (), {'pk': '42'}, ('42/', (), {})),
+    (r'^(\d+)/$', (), {}, NoReverseMatch),
+    (r'^(?P<pk>\d+)/$', (), {}, NoReverseMatch),
+    # Can't use kwargs to reconstruct unnamed groups
+    (r'^(\d+)/$', (), {'pk': '42'}, NoReverseMatch),
+    # But can use args to reconstruct named groups
+    (r'^(?P<pk>\d+)/$', ('42',), {}, ('42/', (), {})),
+
+    (r'^(\d+)/', ('42', '37'), {}, ('42/', ('37',), {})),
+    (r'^(?P<pk>\d+)/', (), {'pk': '42', 'slug': 'test'}, ('42/', (), {'slug': 'test'})),
+)
+
+
+class ConstraintTestCase(SimpleTestCase):
+    def assertMatchEqual(self, constraint, url, request, expected):
+        try:
+            got = constraint.match(url, request)
+        except Resolver404:
+            self.assertEqual(expected, Resolver404)
+        else:
+            self.assertEqual(got, expected)
+
+
+class RegexPatternTests(ConstraintTestCase):
+    def test_regex_pattern(self):
+        pattern = RegexPattern(r'^test/$')
+        self.assertEqual(pattern.regex.pattern, r'^test/$')
+        self.assertEqual(pattern.normalized_patterns, [('test/', [])])
+        self.assertIsInstance(pattern.regex, re._pattern_type)
+
+    def test_describe(self):
+        pattern = RegexPattern(r'^test/$')
+        self.assertEqual(pattern.describe(URL()).describe(), r'^test/$')
+        other_pattern = RegexPattern(r'test/$')
+        self.assertEqual(other_pattern.describe(URL()).describe(), r'test/$')
+
+    def test_regex_match(self):
+        for regex, url, expected in regex_match_data:
+            pattern = RegexPattern(regex)
+            self.assertMatchEqual(pattern, url, None, expected)
+
+    def test_regex_construct(self):
+        for regex, args, kwargs, expected in regex_construct_data:
+            pattern = RegexPattern(regex)
+            url = URL()
+            try:
+                url, args, kwargs = pattern.construct(url, *args, **kwargs)
+            except NoReverseMatch:
+                self.assertEqual(expected, NoReverseMatch)
+            else:
+                self.assertEqual((url.path, args, kwargs), expected)

--- a/tests/urls_tests/test_resolvers.py
+++ b/tests/urls_tests/test_resolvers.py
@@ -1,0 +1,119 @@
+from __future__ import unicode_literals
+
+from django.conf.urls import include, url
+from django.test import RequestFactory, SimpleTestCase
+from django.urls import (
+    BaseResolver, RegexPattern, Resolver, Resolver404, ResolverEndpoint,
+    ResolverMatch,
+)
+
+from .decorators import inner_decorator, outer_decorator
+from .views import empty_view
+
+
+class ResolverTests(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(ResolverTests, cls).setUpClass()
+        cls.rf = RequestFactory()
+
+    def test_match(self):
+        constraints = [
+            RegexPattern(r'^/'),
+            RegexPattern(r'^test/'),
+            RegexPattern(r'^(?P<pk>\d+)/$'),
+        ]
+        urlpattern = url(constraints, empty_view)
+        resolver = BaseResolver(urlpattern)
+        test_url = '/test/42/'
+        request = self.rf.get(test_url)
+        expected = '', (), {'pk': '42'}
+        self.assertEqual(resolver.match(test_url, request), expected)
+
+    def test_no_match(self):
+        constraints = [
+            RegexPattern(r'^/'),
+            RegexPattern(r'^test/'),
+            RegexPattern(r'^(?P<pk>\d+)/$'),
+        ]
+        urlpattern = url(constraints, empty_view)
+        resolver = BaseResolver(urlpattern)
+        test_url = '/no/match/'
+        request = self.rf.get(test_url)
+        with self.assertRaises(Resolver404):
+            resolver.match(test_url, request)
+
+    def test_empty_constraints_match(self):
+        urlpattern = url([], empty_view)
+        resolver = BaseResolver(urlpattern)
+        test_url = '/test/42/'
+        request = self.rf.get(test_url)
+        expected = '/test/42/', (), {}
+        self.assertEqual(resolver.match(test_url, request), expected)
+
+    def test_resolve_to_view(self):
+        constraints = [
+            RegexPattern(r'^/'),
+            RegexPattern(r'^test/$'),
+        ]
+        urlpattern = url(constraints, empty_view, name='empty-view')
+        resolver = ResolverEndpoint(urlpattern)
+        test_url = '/test/'
+        request = self.rf.get(test_url)
+        match = next(resolver.resolve(test_url, request))
+        self.assertEqual(match.__class__, ResolverMatch)
+        self.assertEqual(match.func, empty_view)
+        self.assertEqual(match.args, ())
+        self.assertEqual(match.kwargs, {})
+        self.assertEqual(match.url_name, 'empty-view')
+
+    def test_nested_resolvers(self):
+        included = ([url(r'^detail/$', empty_view, name='empty-view')], 'app1')
+        constraints = [
+            RegexPattern(r'^/'),
+            RegexPattern(r'^(?P<pk>\d+)/'),
+        ]
+        urlpattern = url(constraints, include(included, 'ns1'))
+        resolver = Resolver(urlpattern)
+        test_url = '/42/detail/'
+        request = self.rf.get(test_url)
+        match = next(resolver.resolve(test_url, request))
+        self.assertEqual(match.__class__, ResolverMatch)
+        self.assertEqual(match.func, empty_view)
+        self.assertEqual(match.args, ())
+        self.assertEqual(match.kwargs, {'pk': '42'})
+        self.assertEqual(match.url_name, 'empty-view')
+        self.assertEqual(match.app_name, 'app1')
+        self.assertEqual(match.namespace, 'ns1')
+        self.assertEqual(match.view_name, 'ns1:empty-view')
+
+    def test_decorators(self):
+        included = ([url(r'^detail/$', empty_view, name='empty-view', decorators=[inner_decorator])], 'app1')
+        constraints = [
+            RegexPattern(r'^/'),
+            RegexPattern(r'^(?P<pk>\d+)/'),
+        ]
+        urlpattern = url(constraints, include(included, 'ns1'), decorators=[outer_decorator])
+        resolver = Resolver(urlpattern)
+        test_url = '/42/detail/'
+        request = self.rf.get(test_url)
+        match = next(resolver.resolve(test_url, request))
+        self.assertEqual(match.func, empty_view)
+        self.assertEqual(match.args, ())
+        self.assertEqual(match.kwargs, {'pk': '42'})
+        self.assertEqual(match.callback.decorated_by, 'outer')
+
+    def test_default_kwargs(self):
+        included = ([url(r'^detail/$', empty_view, kwargs={'pk': 'overridden'}, name='empty-view')], 'app1')
+        constraints = [
+            RegexPattern(r'^/'),
+            RegexPattern(r'^(?P<pk>\d+)/'),
+        ]
+        urlpattern = url(constraints, include(included, 'ns1'), kwargs={'test2': '37'})
+        resolver = Resolver(urlpattern)
+        test_url = '/42/detail/'
+        request = self.rf.get(test_url)
+        match = next(resolver.resolve(test_url, request))
+        self.assertEqual(match.func, empty_view)
+        self.assertEqual(match.args, ())
+        self.assertEqual(match.kwargs, {'pk': 'overridden', 'test2': '37'})

--- a/tests/urls_tests/test_utils.py
+++ b/tests/urls_tests/test_utils.py
@@ -1,0 +1,80 @@
+# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.test import SimpleTestCase
+from django.test.client import RequestFactory
+from django.urls import URL
+
+path_data = (
+    # format: (path, query_string, fragment, repr, expected)
+    ('/test/', 'query=true', 'fragment', "<URL '/test/?query=true#fragment'>", '/test/?query=true#fragment'),
+    # and empty url returns an empty string
+    ('', '', '', "<URL ''>", ''),
+    # special characters? no problem.
+    ('/test/?=;@&$', '', '', "<URL '/test/%3F=;@&$'>", '/test/%3F=;@&$'),
+    # # in query string must be encoded
+    (
+        '/test/', 'query=#hashtag', 'fragment', "<URL '/test/?query=%23hashtag#fragment'>",
+        '/test/?query=%23hashtag#fragment',
+    ),
+    # / and ? in query string are allowed
+    ('/test/', 'query/string=what?', '', "<URL '/test/?query%2Fstring=what%3F'>", '/test/?query%2Fstring=what%3F'),
+    # # in fragment is allowed
+    ('/test/', '', '#fragment#', "<URL '/test/##fragment#'>", '/test/##fragment#'),
+    # characters outside ASCII range are encoded in the path
+    ('/I ♥ Django/', '', '', "<URL '/I%20%E2%99%A5%20Django/'>", '/I%20%E2%99%A5%20Django/'),
+    # and in the query string
+    ('/test/', 'django=♥', '', "<URL '/test/?django=%E2%99%A5'>", '/test/?django=%E2%99%A5'),
+    # and in the fragment
+    ('/test/', '', '♥', "<URL '/test/#%E2%99%A5'>", '/test/#%E2%99%A5'),
+)
+
+
+url_data = (
+    # format: (scheme, host, path, query, fragment, expected)
+    ('http', 'example.org', '/', '', '', 'http://example.org/'),
+    ('https', 'example.org', '/test/', 'q', 'fragment', 'https://example.org/test/?q=#fragment'),
+    ('', 'example.org', '/', 'q', 'fragment', '//example.org/?q=#fragment'),
+    ('http', '', '/test/', '', '', 'http:///test/'),
+)
+
+
+class URLTests(SimpleTestCase):
+    def test_url_path(self):
+        for path, query, fragment, url_repr, expected in path_data:
+            url = URL(path=path, query=query, fragment=fragment)
+            self.assertEqual(str(url), expected)
+            self.assertEqual(repr(url), url_repr)
+
+    def test_full_url(self):
+        for scheme, host, path, query, fragment, expected in url_data:
+            url = URL(scheme, host, path, query, fragment)
+            self.assertEqual(str(url), expected)
+
+    def test_from_location(self):
+        url = URL.from_location('http://example.org/test/?query=now#fragment')
+        self.assertEqual(url.scheme, 'http')
+        self.assertEqual(url.host, 'example.org')
+        self.assertEqual(url.path, '/test/')
+        self.assertEqual(url.query['query'], 'now')
+        self.assertEqual(url.fragment, 'fragment')
+
+    def test_from_request(self):
+        request = RequestFactory().get('/test/?query=now#fragment')
+        url = URL.from_request(request)
+        self.assertEqual(url.scheme, 'http')
+        self.assertEqual(url.host, 'testserver')
+        self.assertEqual(url.path, '/test/')
+        self.assertEqual(url.query['query'], 'now')
+        # HttpRequest does not capture the fragment
+        self.assertEqual(url.fragment, '')
+
+    def test_url_copy(self):
+        url = URL('https', 'example.org:8443', '/test/path/', 'copy=1', 'results')
+        copied_url = url.copy()
+        self.assertIsNot(url, copied_url)
+        self.assertEqual(url.scheme, copied_url.scheme)
+        self.assertEqual(url.host, copied_url.host)
+        self.assertEqual(url.path, copied_url.path)
+        self.assertEqual(url.query, copied_url.query)
+        self.assertEqual(url.fragment, copied_url.fragment)

--- a/tests/urls_tests/views.py
+++ b/tests/urls_tests/views.py
@@ -1,0 +1,17 @@
+from __future__ import unicode_literals
+
+from django.http import HttpResponse
+
+
+def empty_view(request):
+    """
+    Return an empty response.
+    """
+    return HttpResponse('')
+
+
+class ViewClass(object):
+    def __call__(self, request):
+        return HttpResponse('')
+
+class_based_view = ViewClass()

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -9,7 +9,7 @@ from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.template import TemplateDoesNotExist
-from django.urls import get_resolver
+from django.urls import get_dispatcher, get_urlconf
 from django.views import View
 from django.views.debug import (
     SafeExceptionReporterFilter, technical_500_response,
@@ -56,8 +56,8 @@ def raises403(request):
 
 
 def raises404(request):
-    resolver = get_resolver(None)
-    resolver.resolve('/not-in-urls')
+    dispatcher = get_dispatcher(get_urlconf())
+    dispatcher.resolve('/not-in-urls')
 
 
 def technical404(request):


### PR DESCRIPTION
Expirimental rewrite of the internals.

Started decoupling of urlconf and resolvers.

Decoupled urlconf/namespace loading in Dispatcher from Resolvers.

Several changes:
- Completed decoupling of Dispatcher and Resolver.
- Moved Dispatcher to its own module.
- Cleaned up some obsolete code.
- Added ScriptPrefix constraint.

Moved around quoting to boost performance.

Avoided cloaking resolver variable in url checks.

Fixed memory leak in Dispatcher._resolve_namespace cache.

Fixed thread-safety issues in Dispatcher.load().

Changed several parts to use the django.conf.urls API instead of the django.urls API.

Refactored Resolver404 for performance.

Small change in ResolverMatch for performance.

Cleaned up handle_uncaught_exception and Resolver.

Refactored URLConf and Include.

Changed URLPattern.is_view to is_endpoint for consistency with Resolver.

Changed 'pattern' to 'urlpattern' for consistency.

Updated error message for NoReverseMatch when no patterns are found.

Cleaned up 404 debug view.

Fixed append slash in CommonMiddleware.

Refactored the reversing part of the dispatcher.

Prepped resolving for possible 'multiurl' behaviour.

Added support for `prefix_default_language` in `i18n_patterns()`.